### PR TITLE
Improve classNames of components

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Props not specified here are considered internal, and are prone to change.
     Property            |   Type        |   Description
 :-----------------------|:--------------|:--------------------------------
     children            |   node        |   Contents
+    className           |   string      |   Class name to add to the wrapper div [default: modal-header]
     isStatic            |   bool        |   If true then the close button won't trigger `onCancel`
     addClose            |   bool        |   Show the close button [default: true]
     onCancel            |   func        |   Callback to trigger when the close button is clicked

--- a/examples/components/App.js
+++ b/examples/components/App.js
@@ -88,6 +88,14 @@ class App extends Component {
                             Modals render react components. This example uses react-remarkable
                             to display markdown
                         </Example>
+
+                        <Example
+                            title="Modal with Header and Body components"
+                            component={examples.WithComponents}
+                            src={EXAMPLE_SRC.WithComponents}
+                        >
+                            Modals can be customized with Modal.Header and Modal.Body components.
+                        </Example>
                     </div>
                 </div>
 

--- a/examples/components/examples/WithComponents.js
+++ b/examples/components/examples/WithComponents.js
@@ -39,13 +39,17 @@ class WithComponentsModalExample extends Component {
                     <a className="btn btn-secondary" onClick={this.props.toggleCode}>Code</a>
                 </div>
 
-                <Modal isOpen={this.state.isOpen} autoWrap onCancel={this.toggleModal}>
-                    <Modal.Header className="modal-header custom-header">
+                <Modal
+                    isOpen={this.state.isOpen}
+                    dialogClassName="modal-dialog custom-dialog"
+                    onCancel={this.toggleModal}
+                >
+                    <Modal.Header className="modal-header custom-header" addClose={false}>
                         Header component!
                     </Modal.Header>
                     <Modal.Body className="modal-body custom-body">
                         <p>
-                            I’m a modal with a Body.
+                            I’m a modal with custom classes for Dialog, Header and Body.
                         </p>
                     </Modal.Body>
                 </Modal>

--- a/examples/components/examples/WithComponents.js
+++ b/examples/components/examples/WithComponents.js
@@ -1,0 +1,57 @@
+import React, { PropTypes, Component } from 'react';
+
+import Modal from '../../../src/browser';
+
+
+class WithComponentsModalExample extends Component {
+    static propTypes = {
+        initialOpen: PropTypes.bool,
+        toggleCode: PropTypes.func.isRequired
+    };
+
+    static defaultProps = {
+        initialOpen: false
+    };
+
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            isOpen: props.initialOpen
+        };
+    }
+
+    toggleModal = (e) => {
+        if (e && e.preventDefault) {
+            e.preventDefault();
+        }
+
+        this.setState({
+            isOpen: !this.state.isOpen
+        });
+    };
+
+    render() {
+        return (
+            <div>
+                <div className="btn-group">
+                    <a className="btn btn-primary" onClick={this.toggleModal}>Open</a>
+                    <a className="btn btn-secondary" onClick={this.props.toggleCode}>Code</a>
+                </div>
+
+                <Modal isOpen={this.state.isOpen} autoWrap onCancel={this.toggleModal}>
+                    <Modal.Header className="modal-header custom-header">
+                        Header component!
+                    </Modal.Header>
+                    <Modal.Body className="modal-body custom-body">
+                        <p>
+                            I’m a modal with a Body.
+                        </p>
+                    </Modal.Body>
+                </Modal>
+            </div>
+        );
+    }
+}
+
+export default WithComponentsModalExample;

--- a/examples/components/examples/index.js
+++ b/examples/components/examples/index.js
@@ -6,3 +6,4 @@ export BasicConfirm from './BasicConfirm';
 export Long from './Long';
 export NestedLong from './NestedLong';
 export Markdown from './Markdown';
+export WithComponents from './WithComponents';

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -19,6 +19,7 @@ class Modal extends Component {
         isStatic: PropTypes.bool,
         isBasic: PropTypes.bool,
         autoWrap: PropTypes.bool,
+        dialogClassName: PropTypes.string,
 
         transitionName: PropTypes.string,
         transitionDuration: PropTypes.number,
@@ -31,6 +32,7 @@ class Modal extends Component {
 
     static defaultProps = {
         autoWrap: false,
+        dialogClassName: 'modal-dialog',
         transitionName: 'fade',
         transitionDuration: 300
     };
@@ -140,7 +142,7 @@ class Modal extends Component {
     }
 
     renderModal() {
-        const { isOpen, isBasic, isStatic } = this.props;
+        const { isOpen, isBasic, isStatic, dialogClassName } = this.props;
 
         if (!isOpen) {
             return [];
@@ -149,7 +151,7 @@ class Modal extends Component {
         const parts = [(
             <Backdrop isStatic={isStatic} onCancel={this.onCancel} key="backdrop" />
         ), (
-            <ModalDialog isBasic={isBasic} onCancel={this.onCancel} key="dialog">
+            <ModalDialog isBasic={isBasic} onCancel={this.onCancel} key="dialog" className={dialogClassName}>
                 {this.renderModalHeader()}
                 {this.renderModalBody()}
             </ModalDialog>

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -31,7 +31,6 @@ class Modal extends Component {
 
     static defaultProps = {
         autoWrap: false,
-        keyboard: true,
         transitionName: 'fade',
         transitionDuration: 300
     };

--- a/src/components/dom/ModalDialog.js
+++ b/src/components/dom/ModalDialog.js
@@ -4,10 +4,15 @@ import React, { Component, PropTypes } from 'react';
 class ModalDialog extends Component {
     static propTypes = {
         children: PropTypes.node,
+        className: PropTypes.string,
 
         onCancel: PropTypes.func.isRequired,
         isBasic: PropTypes.bool,
         animating: PropTypes.bool
+    };
+
+    static defaultProps = {
+        className: 'modal-dialog'
     };
 
     onCancel = (e) => {
@@ -23,12 +28,12 @@ class ModalDialog extends Component {
     };
 
     render() {
-        const { children, isBasic } = this.props;
-        const className = `modal${isBasic ? ' modal-basic' : ''}`;
+        const { children, isBasic, className } = this.props;
+        const wrapperClassName = `modal${isBasic ? ' modal-basic' : ''}`;
 
         return (
-            <div className={className} onClick={this.onCancel}>
-                <div className="modal-dialog">
+            <div className={wrapperClassName} onClick={this.onCancel}>
+                <div className={className}>
                     <div className="modal-content" onClick={this.stopPropagate}>
                         {children}
                     </div>

--- a/src/components/dom/ModalHeader.js
+++ b/src/components/dom/ModalHeader.js
@@ -6,12 +6,14 @@ class ModalHeader extends Component {
 
     static propTypes = {
         children: PropTypes.node,
+        className: PropTypes.string,
         isStatic: PropTypes.bool,
         addClose: PropTypes.bool,
         onCancel: PropTypes.func
     };
 
     static defaultProps = {
+        className: 'modal-header',
         addClose: true
     };
 
@@ -28,7 +30,7 @@ class ModalHeader extends Component {
     };
 
     render() {
-        const { children, addClose } = this.props;
+        const { children, addClose, className } = this.props;
 
         if (typeof children !== 'string') {
             return children;
@@ -39,7 +41,7 @@ class ModalHeader extends Component {
         ) : null;
 
         return (
-            <div className="modal-header">
+            <div className={className}>
                 <h1 className="modal-title">{children}</h1>
                 {closeBtn}
             </div>

--- a/src/components/dom/ModalHeader.js
+++ b/src/components/dom/ModalHeader.js
@@ -30,13 +30,13 @@ class ModalHeader extends Component {
     render() {
         const { children, addClose } = this.props;
 
-        const closeBtn = addClose ? (
-            <button className="close" aria-label="Close" onClick={this.onCancel}><span aria-hidden="true">&times;</span></button>
-        ) : null;
-
         if (typeof children !== 'string') {
             return children;
         }
+
+        const closeBtn = addClose ? (
+            <button className="close" aria-label="Close" onClick={this.onCancel}><span aria-hidden="true">&times;</span></button>
+        ) : null;
 
         return (
             <div className="modal-header">


### PR DESCRIPTION
This PR addresses #22 .

Added className prop for the ModalHeader and modified the render method to return a value once it's known.
Added className prop for the ModalDialog.
Added an example for using the components separately.