### PR TITLE
Make the backdrop bigger

### DIFF
--- a/src/styles/default.scss
+++ b/src/styles/default.scss
@@ -134,7 +134,7 @@ $modal-z-index: 1050;
 
 .modal-backdrop {
     position: fixed;
-    top: 0;
+    top: -100%;
     right: 0;
     bottom: 0;
     left: 0;


### PR DESCRIPTION
This avoids see-through issues at the top edge on mobile browsers when they
hide the location bar and enlarge the viewport.