### PR TITLE
Add Modal warning if `Modal.Header` is manually added

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -41,6 +41,15 @@ class Modal extends Component {
         super(props);
 
         this.state = {};
+
+        // validate children props and warn if something is wrong
+        React.Children.forEach(props.children, (child) => {
+            if (child && child.type === ModalHeader) {
+                if (child.props.addClose && !child.props.onCancel) {
+                    console.warn(`${ModalHeader.displayName}: addClose is defined but onCancel is missing!`);
+                }
+            }
+        });
     }
 
     componentDidMount() {
@@ -110,16 +119,35 @@ class Modal extends Component {
         });
     };
 
+    renderChild = (child) => {
+        if (!child) {
+            return child;
+        }
+
+        const { onCancel: onCancel } = this.props;
+        const { addClose, headerOnCancel } = child.props || {};
+
+        if (child.type === ModalHeader && addClose && !headerOnCancel) {
+            return React.cloneElement(child, {
+                ...child.props,
+                onCancel
+            });
+        }
+
+        return child;
+    };
+
     renderModalBody() {
+        const children = React.Children.map(this.props.children, this.renderChild);
         if (this.props.autoWrap) {
             return (
                 <ModalBody>
-                    {this.props.children}
+                    {children}
                 </ModalBody>
             );
         }
 
-        return this.props.children;
+        return children;
     }
 
     renderModalHeader() {

--- a/src/components/dom/ModalHeader.js
+++ b/src/components/dom/ModalHeader.js
@@ -17,6 +17,15 @@ class ModalHeader extends Component {
         addClose: true
     };
 
+    constructor(props) {
+        super(props);
+
+        // warn if something is wrong with props
+        if (props.addClose && !props.onCancel) {
+            console.warn(`${ModalHeader.displayName}: addClose is defined but onCancel is missing!`);
+        }
+    }
+
     onCancel = (e) => {
         /* istanbul ignore else */
         if (e && e.preventDefault) {

--- a/test/test-ModalHeader.js
+++ b/test/test-ModalHeader.js
@@ -12,7 +12,13 @@ import { buildContainer } from './util';
 
 describe('ModalHeader', () => {
     it('renders correctly', () => {
+        const spyConsoleWarn = sinon.spy();
+        console.warn = spyConsoleWarn;
+
         const container = ReactDOM.findDOMNode(buildContainer(ModalHeader, { children: 'Hello world' }));
+
+        // test spy was not called yet
+        assert.equal(spyConsoleWarn.callCount, 1);
 
         // Its a div
         assert.equal(container.nodeName, 'DIV');
@@ -31,14 +37,26 @@ describe('ModalHeader', () => {
     });
 
     it('raw children work', () => {
+        const spyConsoleWarn = sinon.spy();
+        console.warn = spyConsoleWarn;
+
         const container = ReactDOM.findDOMNode(buildContainer(ModalHeader, { children: (<span>Sup</span>) }));
+
+        // test spy was not called yet
+        assert.equal(spyConsoleWarn.callCount, 1);
 
         assert.equal(container.nodeName, 'SPAN');
         assert.equal(container.textContent, 'Sup');
     });
 
     it('className works', () => {
+        const spyConsoleWarn = sinon.spy();
+        console.warn = spyConsoleWarn;
+
         const container = ReactDOM.findDOMNode(buildContainer(ModalHeader, { className: 'foo', children: 'Hello world' }));
+
+        // test spy was not called yet
+        assert.equal(spyConsoleWarn.callCount, 1);
 
         // Its a div
         assert.equal(container.nodeName, 'DIV');
@@ -88,6 +106,22 @@ describe('ModalHeader', () => {
 
         // test spy was not called
         assert.equal(spy.callCount, 0);
+    });
+
+    it('addClose is defined and onCancel is not defined', () => {
+        const spyConsoleWarn = sinon.spy();
+        console.warn = spyConsoleWarn;
+
+        const container = ReactDOM.findDOMNode(buildContainer(ModalHeader, { children: 'Hello world', addClose: true }));
+
+        // test spy was not called yet
+        assert.equal(spyConsoleWarn.callCount, 1);
+
+        // Close button is rendered into the container
+        assert.equal(container.querySelectorAll('button.close').length, 1);
+
+        // Trigger click
+        TestUtils.Simulate.click(container.querySelector('button.close'));
     });
 
     it('click handler works w/o onCancel', () => {


### PR DESCRIPTION
- Added Modal warning if `Modal.Header` addClose is and onCancel is not defined
- Added `Modal.Header` cloning and adding `Modal.props.onCancel` if `Modal.Header.props.addClose` is defined

Fixes #33