### PR TITLE
Ensure all our css classes begin w/ `tg-modal`

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ This will render a static modal, which cannot be hidden by the user.
 | keyboard            | bool   | Should the modal listen to keyboard events (`ENTER` or `ESCAPE` press) [default: true] 
 | autoWrap            | bool   | If true, children will be wrapped inside `Modal.Body` [default: false] 
 | onToggle            | func   | Function called after the modal is toggled. `function (isOpen, props) { }` 
-| transitionName      | string | Name of animation to use for open/close (to see how to define custom ones, see default styles) [default: fade] 
-| transitionDuration  | int    | Duration of the transition in milliseconds [default: 300] 
+| transitionName      | string | Name of animation to use for open/close (to see how to define custom ones, see default styles) [default: tg-modal-fade]
+| transitionDuration  | int    | Duration of the transition in milliseconds [default: 300]
+| dialogClassName     | string | Classname to use for `ModalDialog` [default: tg-modal-dialog]
 
 Props not specified here are considered internal, and are prone to change.
 
@@ -75,7 +76,7 @@ Props not specified here are considered internal, and are prone to change.
 | Property            | Type        | Description 
 |---------------------|-------------|--------------
 | children            | node        | Contents 
-| className           | string      | Class name to add to the wrapper div [default: modal-header] 
+| className           | string      | Class name to add to the wrapper div [default: tg-modal-header]
 | isStatic            | bool        | If true, the close button won't trigger `onCancel` 
 | addClose            | bool        | Show the close button [default: true]
 | onCancel            | func        | Callback to trigger when the close button is clicked
@@ -85,7 +86,7 @@ Props not specified here are considered internal, and are prone to change.
 | Property            | Type        | Description
 |---------------------|-------------|--------------------------------
 | children            | node        | Contents
-| className           | string      | Class name to add to the wrapper div [default: modal-body]
+| className           | string      | Class name to add to the wrapper div [default: tg-modal-body]
 
 ### Examples
 

--- a/examples/components/examples/BasicConfirm.js
+++ b/examples/components/examples/BasicConfirm.js
@@ -67,7 +67,7 @@ class BasicConfirmModalExample extends Component {
                             You can also use <b>enter</b> or <b>escape</b> to accept or decline.
                         </p>
                     </Modal.Body>
-                    <div className="modal-footer">
+                    <div className="tg-modal-footer">
                         <a className="btn btn-primary" onClick={this.onConfirm}>OH YES</a>
                         <a className="btn btn-secondary" onClick={this.onCancel}>NOPE</a>
                     </div>

--- a/examples/components/examples/Confirm.js
+++ b/examples/components/examples/Confirm.js
@@ -72,7 +72,7 @@ class ConfirmModalExample extends Component {
                             You can also use <b>enter</b> or <b>escape</b> to accept or decline.
                         </p>
                     </Modal.Body>
-                    <div className="modal-footer">
+                    <div className="tg-modal-footer">
                         <a className="btn btn-primary" onClick={this.onConfirm}>OH YES</a>
                         <a className="btn btn-secondary" onClick={this.onCancel}>NOPE</a>
                     </div>

--- a/examples/components/examples/Static.js
+++ b/examples/components/examples/Static.js
@@ -42,7 +42,7 @@ class StaticModalExample extends Component {
                         </p>
                     </Modal.Body>
 
-                    <div className="modal-footer">
+                    <div className="tg-modal-footer">
                         <a className="btn btn-primary" onClick={this.toggleModal}>Close</a>
                     </div>
                 </Modal>

--- a/examples/components/examples/WithComponents.js
+++ b/examples/components/examples/WithComponents.js
@@ -42,13 +42,13 @@ class WithComponentsModalExample extends Component {
 
                 <Modal
                     isOpen={this.state.isOpen}
-                    dialogClassName="modal-dialog custom-dialog"
+                    dialogClassName="tg-modal-dialog custom-dialog"
                     onCancel={this.toggleModal}
                 >
-                    <Modal.Header className="modal-header custom-header" addClose={false}>
+                    <Modal.Header className="tg-modal-header custom-header" addClose={false}>
                         Header component!
                     </Modal.Header>
-                    <Modal.Body className="modal-body custom-body">
+                    <Modal.Body className="tg-modal-body custom-body">
                         <p>
                             I’m a modal with custom classes for Dialog, Header and Body.
                         </p>

--- a/examples/styles/_base.scss
+++ b/examples/styles/_base.scss
@@ -149,7 +149,7 @@ a {
 
 .container {
     .markdown-wrapper {
-        .modal-body {
+        .tg-modal-body {
             text-align: left;
         }
     }
@@ -173,7 +173,7 @@ a {
 }
 
 
-.modal-body {
+.tg-modal-body {
     hr {
         margin: 16px 0;
         border: 0 none transparent;

--- a/examples/styles/main.scss
+++ b/examples/styles/main.scss
@@ -81,39 +81,39 @@
 
 
 .container {
-    .modal {
+    .tg-modal {
         text-align: center;
 
-        .modal-dialog .modal-content {
+        .tg-modal-dialog .tg-modal-content {
             border-radius: 5px;
 
-            .modal-header {
+            .tg-modal-header {
                 padding-bottom: 0;
 
-                .modal-title {
+                .tg-modal-title {
                     font-size: 45px;
                     line-height: 54px;
                     margin-bottom: 20px;
                 }
 
-                .close {
+                .tg-modal-close {
                     font-family: $headings-font-family;
                     font-size: 24px;
                     border-radius: 5px;
                 }
             }
 
-            .modal-body {
+            .tg-modal-body {
                 padding-left: 50px;
                 padding-right: 50px;
             }
 
-            .modal-footer {
+            .tg-modal-footer {
                 padding-top: 0;
             }
         }
 
-        &.modal-basic {
+        &.tg-modal-basic {
             &, h1, p {
                 color: #fff;
             }
@@ -122,7 +122,7 @@
 }
 
 .long {
-    .modal-body {
+    .tg-modal-body {
         &, p {
             color: #798489;
             font-family: $content-font-family;

--- a/src/browser.js
+++ b/src/browser.js
@@ -52,7 +52,7 @@ class BrowserModal extends Modal {
     getToggleProps(isOpen) {
         return {
             scrollbarSize: typeof document !== 'undefined' ? getScrollbarSize() : null,
-            className: isOpen ? 'modal-open' : ''
+            className: isOpen ? 'tg-modal-open' : ''
         };
     }
 
@@ -85,7 +85,7 @@ class BrowserModal extends Modal {
             if (numberOfModalsOpen === 1) {
 
                 // Toggle open class.
-                toggleClass(container, 'modal-open', state);
+                toggleClass(container, 'tg-modal-open', state);
 
                 if (state) {
                     this._origPadding = container.style.paddingRight;
@@ -143,7 +143,7 @@ class BrowserModal extends Modal {
         return {
             ...super.getAnimatorGroupProps(),
             component: 'div',
-            className: `modal-wrapper${this.state.animating ? ' animating' : ''}`
+            className: `tg-modal-wrapper${this.state.animating ? ' tg-modal-animating' : ''}`
         };
     }
 }

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -36,8 +36,8 @@ class Modal extends Component {
 
     static defaultProps = {
         autoWrap: false,
-        dialogClassName: 'modal-dialog',
-        transitionName: 'fade',
+        dialogClassName: 'tg-modal-dialog',
+        transitionName: 'tg-modal-fade',
         transitionDuration: 300
     };
 

--- a/src/components/dom/Backdrop.js
+++ b/src/components/dom/Backdrop.js
@@ -10,7 +10,7 @@ class Backdrop extends Component {
     };
 
     static defaultProps = {
-        className: 'modal-backdrop'
+        className: 'tg-modal-backdrop'
     };
 
     onCancel = (e) => {

--- a/src/components/dom/ModalBody.js
+++ b/src/components/dom/ModalBody.js
@@ -10,7 +10,7 @@ class ModalBody extends Component {
     };
 
     static defaultProps = {
-        className: 'modal-body'
+        className: 'tg-modal-body'
     };
 
     render() {

--- a/src/components/dom/ModalDialog.js
+++ b/src/components/dom/ModalDialog.js
@@ -12,7 +12,7 @@ class ModalDialog extends Component {
     };
 
     static defaultProps = {
-        className: 'modal-dialog'
+        className: 'tg-modal-dialog'
     };
 
     onCancel = (e) => {
@@ -30,12 +30,12 @@ class ModalDialog extends Component {
 
     render() {
         const { children, isBasic, className } = this.props;
-        const wrapperClassName = `modal${isBasic ? ' modal-basic' : ''}`;
+        const wrapperClassName = `tg-modal${isBasic ? ' tg-modal-basic' : ''}`;
 
         return (
             <div className={wrapperClassName} onClick={this.onCancel}>
                 <div className={className}>
-                    <div className="modal-content" onClick={this.stopPropagate}>
+                    <div className="tg-modal-content" onClick={this.stopPropagate}>
                         {children}
                     </div>
                 </div>

--- a/src/components/dom/ModalHeader.js
+++ b/src/components/dom/ModalHeader.js
@@ -14,7 +14,7 @@ class ModalHeader extends Component {
     };
 
     static defaultProps = {
-        className: 'modal-header',
+        className: 'tg-modal-header',
         addClose: true
     };
 
@@ -48,12 +48,12 @@ class ModalHeader extends Component {
         }
 
         const closeBtn = addClose ? (
-            <button className="close" aria-label="Close" onClick={this.onCancel}><span aria-hidden="true">&times;</span></button>
+            <button className="tg-modal-close" aria-label="Close" onClick={this.onCancel}><span aria-hidden="true">&times;</span></button>
         ) : null;
 
         return (
             <div className={className}>
-                <h1 className="modal-title">{children}</h1>
+                <h1 className="tg-modal-title">{children}</h1>
                 {closeBtn}
             </div>
         );

--- a/src/styles/default.scss
+++ b/src/styles/default.scss
@@ -1,18 +1,18 @@
 // default.scss
 
-body.modal-open {
+body.tg-modal-open {
     overflow: hidden;
 }
 
 $modal-z-index: 1050;
 
-.modal, .modal-backdrop {
+.tg-modal, .tg-modal-backdrop {
     transform-style: preserve-3d;
     backface-visibility: hidden;
     transform: translate3d(0,0,0)
 }
 
-.modal {
+.tg-modal {
     position: fixed;
     top: 0;
     right: 0;
@@ -25,7 +25,7 @@ $modal-z-index: 1050;
 
     transform-origin: 50% 25%;
 
-    .modal-dialog {
+    .tg-modal-dialog {
         position: relative;
         width: auto;
         margin: 10px;
@@ -36,15 +36,15 @@ $modal-z-index: 1050;
             margin: 30px auto;
         }
 
-        .modal-content {
+        .tg-modal-content {
             background: #fff;
             padding: 0;
 
-            .modal-header {
+            .tg-modal-header {
                 padding: 1.8rem 1.5rem;
                 position: relative;
 
-                .modal-title {
+                .tg-modal-title {
                     padding: 0;
                     margin: 0;
 
@@ -53,7 +53,7 @@ $modal-z-index: 1050;
                     font-weight: 500;
                 }
 
-                .close {
+                .tg-modal-close {
                     cursor: pointer;
                     position: absolute;
                     top: 1.8rem;
@@ -80,7 +80,7 @@ $modal-z-index: 1050;
                 }
             }
 
-            .modal-body {
+            .tg-modal-body {
                 padding: 1.8rem 1.5rem;
                 position: relative;
 
@@ -90,7 +90,7 @@ $modal-z-index: 1050;
                 }
             }
 
-            .modal-footer {
+            .tg-modal-footer {
                 padding: 1.8rem 1.5rem;
                 position: relative;
 
@@ -99,40 +99,40 @@ $modal-z-index: 1050;
                 }
             }
 
-            .modal-header + .modal-body {
+            .tg-modal-header + .tg-modal-body {
                 padding-top: 0;
             }
         }
     }
 
-    &.modal-basic {
-        .modal-dialog {
+    &.tg-modal-basic {
+        .tg-modal-dialog {
             top: 40%;
             transform: translateY(-50%);
             position: absolute;
             left: 0;
             right: 0;
 
-            .modal-content {
+            .tg-modal-content {
                 background: transparent;
                 color: #fff;
                 text-align: center;
 
-                .modal-header {
-                    .close {
+                .tg-modal-header {
+                    .tg-modal-close {
                         display: none;
                     }
                 }
             }
 
-            .modal-footer {
+            .tg-modal-footer {
                 text-align: center;
             }
         }
     }
 }
 
-.modal-backdrop {
+.tg-modal-backdrop {
     position: fixed;
     top: -100%;
     right: 0;
@@ -143,29 +143,29 @@ $modal-z-index: 1050;
     background: rgba(#000, 0.85);
 }
 
-.modal-open .modal {
+.tg-modal-open .tg-modal {
     overflow-x: hidden;
     overflow-y: auto;
 }
 
-.modal-wrapper.animating {
-    .modal {
+.tg-modal-wrapper.tg-modal-animating {
+    .tg-modal {
         overflow: hidden;
         user-select: none;
     }
 }
 
-@keyframes fadeIn {
+@keyframes tg-modal-fade-in {
   from {opacity: 0;}
   to {opacity: 1;}
 }
 
-@keyframes fadeOut {
+@keyframes tg-modal-fade-out {
   from {opacity: 1;}
   to {opacity: 0;}
 }
 
-@keyframes scaleIn {
+@keyframes tg-modal-scale-in {
     from {
         opacity: 0;
         transform: scale(0.8);
@@ -176,7 +176,7 @@ $modal-z-index: 1050;
     }
 }
 
-@keyframes scaleOut {
+@keyframes tg-modal-scale-out {
     from {
         opacity: 1;
         transform: scale(1);
@@ -187,24 +187,24 @@ $modal-z-index: 1050;
     }
 }
 
-.fade-enter {
-    &.modal {
-        animation: scaleIn 300ms ease;
+.tg-modal-fade-enter {
+    &.tg-modal {
+        animation: tg-modal-scale-in 300ms ease;
     }
 
-    &.modal-backdrop {
-        animation: fadeIn 300ms ease;
+    &.tg-modal-backdrop {
+        animation: tg-modal-fade-in 300ms ease;
     }
 }
 
-.fade-exit {
-    &.modal {
-        animation: scaleOut 300ms ease;
+.tg-modal-fade-exit {
+    &.tg-modal {
+        animation: tg-modal-scale-out 300ms ease;
         animation-fill-mode: forwards;
     }
 
-    &.modal-backdrop {
-        animation: fadeOut 300ms ease;
+    &.tg-modal-backdrop {
+        animation: tg-modal-fade-out 300ms ease;
         animation-fill-mode: forwards;
     }
 }

--- a/test/test-Backdrop.js
+++ b/test/test-Backdrop.js
@@ -17,7 +17,7 @@ describe('Modal Backdrop', () => {
         assert.equal(container.nodeName, 'DIV');
 
         // It has the correct default class
-        assert.ok(container.classList.contains('modal-backdrop'));
+        assert.ok(container.classList.contains('tg-modal-backdrop'));
     });
 
     it('onCancel is called after click', () => {

--- a/test/test-ModalBody.js
+++ b/test/test-ModalBody.js
@@ -15,7 +15,7 @@ describe('ModalBody', () => {
         assert.equal(container.nodeName, 'DIV');
 
         // It has the correct default class
-        assert.ok(container.classList.contains('modal-body'));
+        assert.ok(container.classList.contains('tg-modal-body'));
     });
 
     it('className works', () => {

--- a/test/test-ModalDialog.js
+++ b/test/test-ModalDialog.js
@@ -17,14 +17,14 @@ describe('ModalDialog', () => {
         // Its a div
         assert.equal(container.nodeName, 'DIV');
 
-        assert.ok(container.classList.contains('modal'));
+        assert.ok(container.classList.contains('tg-modal'));
 
         // It has the correct default class
-        assert.equal(container.querySelectorAll('.modal-dialog').length, 1);
+        assert.equal(container.querySelectorAll('.tg-modal-dialog').length, 1);
 
         // Run stopPropagate
-        assert.equal(container.querySelectorAll('.modal-content').length, 1);
-        TestUtils.Simulate.click(container.querySelector('.modal-content'));
+        assert.equal(container.querySelectorAll('.tg-modal-content').length, 1);
+        TestUtils.Simulate.click(container.querySelector('.tg-modal-content'));
     });
 
     it('isBasic works', () => {
@@ -34,10 +34,10 @@ describe('ModalDialog', () => {
         assert.equal(container.nodeName, 'DIV');
 
         // It has modal-basic
-        assert.ok(container.classList.contains('modal-basic'));
+        assert.ok(container.classList.contains('tg-modal-basic'));
 
         // It has the correct default class
-        assert.ok(container.classList.contains('modal'));
+        assert.ok(container.classList.contains('tg-modal'));
     });
 
     it('onCancel is called after click', () => {
@@ -70,10 +70,10 @@ describe('ModalDialog', () => {
         assert.equal(spy.callCount, 0);
 
         // Close button is rendered into the container
-        assert.equal(container.querySelectorAll('.modal-content').length, 1);
+        assert.equal(container.querySelectorAll('.tg-modal-content').length, 1);
 
         // Trigger click
-        TestUtils.Simulate.click(container.querySelector('.modal-content'));
+        TestUtils.Simulate.click(container.querySelector('.tg-modal-content'));
 
         // test spy was called once
         assert.equal(spy.callCount, 1);
@@ -83,7 +83,6 @@ describe('ModalDialog', () => {
 
         // test spy wasn't called
         assert.equal(spy.callCount, 1);
-
     });
 
     it('custom children work', () => {

--- a/test/test-ModalHeader.js
+++ b/test/test-ModalHeader.js
@@ -24,16 +24,16 @@ describe('ModalHeader', () => {
         assert.equal(container.nodeName, 'DIV');
 
         // It has the correct default class
-        assert.ok(container.classList.contains('modal-header'));
+        assert.ok(container.classList.contains('tg-modal-header'));
 
         // H1 is rendered into the container
-        assert.equal(container.querySelectorAll('h1.modal-title').length, 1);
+        assert.equal(container.querySelectorAll('h1.tg-modal-title').length, 1);
 
         // H1 value is correct
-        assert.equal(container.querySelector('h1.modal-title').textContent, 'Hello world');
+        assert.equal(container.querySelector('h1.tg-modal-title').textContent, 'Hello world');
 
         // Close button is rendered into the container
-        assert.equal(container.querySelectorAll('button.close').length, 1);
+        assert.equal(container.querySelectorAll('button.tg-modal-close').length, 1);
     });
 
     it('raw children work', () => {
@@ -69,7 +69,7 @@ describe('ModalHeader', () => {
         const container = ReactDOM.findDOMNode(buildContainer(ModalHeader, { addClose: false, children: 'Hello world' }));
 
         // Close button is not rendered into the container
-        assert.equal(container.querySelectorAll('button.close').length, 0);
+        assert.equal(container.querySelectorAll('button.tg-modal-close').length, 0);
     });
 
     it('onCancel is called after click', () => {
@@ -81,10 +81,10 @@ describe('ModalHeader', () => {
         assert.equal(spy.callCount, 0);
 
         // Close button is rendered into the container
-        assert.equal(container.querySelectorAll('button.close').length, 1);
+        assert.equal(container.querySelectorAll('button.tg-modal-close').length, 1);
 
         // Trigger click
-        TestUtils.Simulate.click(container.querySelector('button.close'));
+        TestUtils.Simulate.click(container.querySelector('button.tg-modal-close'));
 
         // test spy was called once
         assert.equal(spy.callCount, 1);
@@ -99,10 +99,10 @@ describe('ModalHeader', () => {
         assert.equal(spy.callCount, 0);
 
         // Close button is rendered into the container
-        assert.equal(container.querySelectorAll('button.close').length, 1);
+        assert.equal(container.querySelectorAll('button.tg-modal-close').length, 1);
 
         // Trigger click
-        TestUtils.Simulate.click(container.querySelector('button.close'));
+        TestUtils.Simulate.click(container.querySelector('button.tg-modal-close'));
 
         // test spy was not called
         assert.equal(spy.callCount, 0);
@@ -118,19 +118,19 @@ describe('ModalHeader', () => {
         assert.equal(spyConsoleWarn.callCount, 1);
 
         // Close button is rendered into the container
-        assert.equal(container.querySelectorAll('button.close').length, 1);
+        assert.equal(container.querySelectorAll('button.tg-modal-close').length, 1);
 
         // Trigger click
-        TestUtils.Simulate.click(container.querySelector('button.close'));
+        TestUtils.Simulate.click(container.querySelector('button.tg-modal-close'));
     });
 
     it('click handler works w/o onCancel', () => {
         const container = ReactDOM.findDOMNode(buildContainer(ModalHeader, { children: 'Hello world' }));
 
         // Close button is rendered into the container
-        assert.equal(container.querySelectorAll('button.close').length, 1);
+        assert.equal(container.querySelectorAll('button.tg-modal-close').length, 1);
 
         // Trigger click
-        TestUtils.Simulate.click(container.querySelector('button.close'));
+        TestUtils.Simulate.click(container.querySelector('button.tg-modal-close'));
     });
 });


### PR DESCRIPTION
- Modal: dialogClassName default changed to `tg-modal-dialog`
- Modal: transitionName default changed to `tg-modal-fade`
- Modal.Header, Modal.Body, Modal.Backdrop, Modal.Dialog:
  - className default changed to new variant

All css changes:

- `.modal` -> `.tg-modal`
- `.modal-dialog` -> `.tg-modal-dialog`
- `.modal-content` -> `.tg-modal-content`
- `.modal-header` -> `.tg-modal-header`
- `.modal-title` -> `.tg-modal-title`
- `.close` -> `.tg-modal-close`
- `.modal-body` -> `.tg-modal-body`
- `.modal-footer` -> `.tg-modal-footer`
- `.modal-basic` -> `.tg-modal-basic`
- `.modal-backdrop` -> `.tg-modal-backdrop`
- `.modal-open` -> `.tg-modal-open`
- `.animating` -> `.tg-modal-animating`
- Keyframe `fadeIn` -> `tg-modal-fade-in`
- Keyframe `fadeOut` -> `tg-modal-fade-out`
- Keyframe `scaleIn` -> `tg-modal-scale-in`
- Keyframe `scaleOut` -> `tg-modal-scale-out`
- `.fade-enter` -> `.tg-modal-fade-enter`
- `.fade-exit` -> `.tg-modal-fade-exit`

fixes #30