### PR TITLE
By default only listen on keyboard when open

### DIFF
--- a/examples/styles/_base.scss
+++ b/examples/styles/_base.scss
@@ -114,6 +114,10 @@ a {
         outline: none;
     }
 
+    &::-moz-focus-inner {
+        border: 0;
+    }
+
     &:hover {
         text-decoration: none;
     }

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -20,6 +20,8 @@ const keyCodes = {
     ENTER: 13,
 };
 
+const shouldBindKeyboard = ({ isOpen, keyboard }) => (keyboard === null ? isOpen : keyboard);
+
 class Modal extends Component {
     static displayName = 'Modal';
 
@@ -47,7 +49,8 @@ class Modal extends Component {
 
         style: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 
-        // Enable/disable keyboard events
+        // Enable/disable keyboard events.
+        // When null, the default, it will behave as having same value as isOpen
         keyboard: PropTypes.bool,
 
         // Enable/disable body scroll locking
@@ -72,7 +75,7 @@ class Modal extends Component {
         transitionName: 'tg-modal-fade',
         transitionDuration: 300,
 
-        keyboard: true,
+        keyboard: null,
 
         onToggle: null,
         onConfirm: null,
@@ -111,16 +114,14 @@ class Modal extends Component {
         this.onToggle(isOpen, this.getToggleProps());
 
         if (typeof document !== 'undefined') {
-            const { keyboard } = this.props;
-
-            if (keyboard) {
+            if (shouldBindKeyboard(this.props)) {
                 this.bindKeyboard();
             }
         }
     }
 
     componentDidUpdate(prevProps, prevState) {
-        const { isOpen, keyboard } = this.props;
+        const { isOpen } = this.props;
 
         if (prevProps.isOpen !== isOpen) {
             this.setState({
@@ -134,8 +135,10 @@ class Modal extends Component {
             this.onToggle(isOpen, this.getToggleProps());
         }
 
-        if (prevProps.keyboard !== keyboard) {
-            if (keyboard) {
+        const wasBound = shouldBindKeyboard(prevProps);
+        const shouldBind = shouldBindKeyboard(this.props);
+        if (wasBound !== shouldBind) {
+            if (shouldBind) {
                 this.bindKeyboard();
             } else {
                 this.unbindKeyboard();

--- a/test/test-Modal.js
+++ b/test/test-Modal.js
@@ -81,4 +81,34 @@ describe('Modal', () => {
         const bodyNode = node.find(Modal.Body).shallow();
         expect(bodyNode.find('.tg-modal-body').text()).to.equal('hello');
     });
+
+    it('Adds event listener when open', () => {
+        let boundEventListener = false;
+        global.document.addEventListener = () => {
+            boundEventListener = true;
+        };
+
+        shallow(<Modal onCancel={onCancel} isOpen />);
+        expect(boundEventListener).to.equal(true);
+    });
+
+    it('Does not add event listener when closed', () => {
+        let boundEventListener = false;
+        global.document.addEventListener = () => {
+            boundEventListener = true;
+        };
+
+        shallow(<Modal onCancel={onCancel} isOpen={false} />);
+        expect(boundEventListener).to.equal(false);
+    });
+
+    it('Adds event listener when closed if keyboard is passed in', () => {
+        let boundEventListener = false;
+        global.document.addEventListener = () => {
+            boundEventListener = true;
+        };
+
+        shallow(<Modal onCancel={onCancel} isOpen={false} keyboard />);
+        expect(boundEventListener).to.equal(true);
+    });
 });


### PR DESCRIPTION
When having multiple modals on the page:

```
<Modal isOpen={false} />
<Modal isOpen={false} />
<Modal isOpen={false} />
```

Hitting enter anywhere on page will trigger `onSubmit` on one of the modals (whichever mounted first it seems).

I can avoid this by passing `isOpen={isOpen} keyboard={isOpen}`.

This makes that that behavior the default when `keyboard` is left out